### PR TITLE
Fix space sequence loop

### DIFF
--- a/src/parser.zig
+++ b/src/parser.zig
@@ -378,3 +378,49 @@ test "Parse combined value with raw 2" {
         else => try testing.expect(false),
     }
 }
+
+test "Parse with sequence space" {
+    const testing = std.testing;
+    const allocator = testing.allocator;
+    const data =
+        \\tags: 
+        \\  - fleeting
+        \\created: 2025-08-08T03:02:00
+        \\cssclasses: 
+        \\  - center-h1
+    ;
+
+    var parser = try Parser.init(allocator, data);
+    defer parser.deinit();
+
+    var arena = ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const value = try parser.parse(arena.allocator());
+    defer value.deinit();
+
+    try testing.expectEqual(3, value.items.len);
+    switch (value.items[0]) {
+        .Sequence => |seq| {
+            try testing.expectEqual(1, seq.value.items.len);
+            try testing.expectEqualStrings("tags", seq.key.items);
+            try testing.expectEqualStrings("fleeting", seq.value.items[0].items);
+        },
+        else => try testing.expect(false),
+    }
+
+    switch (value.items[1]) {
+        .Scalar => |scalar| {
+            try testing.expectEqualStrings("created", scalar.key.items);
+        },
+        else => try testing.expect(false),
+    }
+
+    switch (value.items[2]) {
+        .Sequence => |seq| {
+            try testing.expectEqual(1, seq.value.items.len);
+            try testing.expectEqualStrings("cssclasses", seq.key.items);
+            try testing.expectEqualStrings("center-h1", seq.value.items[0].items);
+        },
+        else => try testing.expect(false),
+    }
+}

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -119,6 +119,20 @@ pub const Parser = struct {
         switch (curr_tok) {
             .Indent => {
                 self.advance();
+                if (self.check(TokenType.EndLine)) {
+                    self.advance();
+                    const token = self.current() orelse return Error.UnexpectedToken;
+                    switch (token) {
+                        .Indent => |n| {
+                            const sequence = try self.parse_sequence(allocator, n);
+                            return Value{ .Sequence = .{
+                                .key = key_str,
+                                .value = sequence,
+                            } };
+                        },
+                        else => return Error.UnexpectedToken,
+                    }
+                }
                 const val = try self.get_multiple_value(allocator);
 
                 return Value{ .Scalar = .{

--- a/src/root.zig
+++ b/src/root.zig
@@ -1,1 +1,6 @@
 pub const Parser = @import("./parser.zig").Parser;
+
+test {
+    _ = @import("./lexer.zig");
+    _ = @import("./parser.zig");
+}


### PR DESCRIPTION
Fix: #1 

The suspect is not on the `get_multiple_value` but at `parse_value` that identify sequence into normal scalar value.